### PR TITLE
Avoid pip wheel caching

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,21 @@ import os
 import sys
 from datetime import datetime, MAXYEAR
 from collections import namedtuple
+import setuptools
 
-from setuptools import setup
-from setuptools.command.install import install
+try:
+    from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 
+    class bdist_wheel(_bdist_wheel):
+        def run(self):
+            raise setuptools.errors.ClassError(
+                "This is an expected error. Buidling wheel is disabled for the sklearn package to avoid client-side pip caching."
+            )
+
+    cmdclass = {"bdist_wheel": bdist_wheel}
+
+except ImportError:
+    cmdclass = {}
 
 with open("README.md") as f:
     LONG_DESCRIPTION = f.read()
@@ -101,10 +112,11 @@ if __name__ == "__main__":
 
         maybe_raise_error(checked_datetime)
 
-    setup(
+    setuptools.setup(
         description="deprecated sklearn package, use scikit-learn instead",
         long_description=LONG_DESCRIPTION,
         long_description_content_type="text/markdown",
         name="sklearn",
         version="0.0.post1",
+        cmdclass=cmdclass,
     )

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,10 @@ try:
         def run(self):
             message = "\n".join(
                 [
-                    "This is an expected error. Building wheel is disabled for the deprecated sklearn PyPI package to avoid pip caching.",
-                    "For more details about the sklearn PyPI package deprecation, see https://github.com/scikit-learn/sklearn-pypi-package"
+                    "This is an expected error. Building wheel is disabled "
+                    "for the deprecated sklearn PyPI package to avoid pip caching.",
+                    "For more details about the sklearn PyPI package deprecation, see:",
+                    "https://github.com/scikit-learn/sklearn-pypi-package",
                 ]
             )
             raise setuptools.errors.ClassError(message)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ try:
     class bdist_wheel(_bdist_wheel):
         def run(self):
             raise setuptools.errors.ClassError(
-                "This is an expected error. Buidling wheel is disabled for the sklearn package to avoid client-side pip caching."
+                "This is an expected error. Building wheel is disabled for the sklearn package to avoid client-side pip caching."
             )
 
     cmdclass = {"bdist_wheel": bdist_wheel}

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,13 @@ try:
 
     class bdist_wheel(_bdist_wheel):
         def run(self):
-            raise setuptools.errors.ClassError(
-                "This is an expected error. Building wheel is disabled for the sklearn package to avoid client-side pip caching."
+            message = "\n".join(
+                [
+                    "This is an expected error. Building wheel is disabled for the deprecated sklearn PyPI package to avoid pip caching.",
+                    "For more details about the sklearn PyPI package deprecation, see https://github.com/scikit-learn/sklearn-pypi-package"
+                ]
             )
+            raise setuptools.errors.ClassError(message)
 
     cmdclass = {"bdist_wheel": bdist_wheel}
 


### PR DESCRIPTION
Currently a wheel is built on the first download and then reused on the next `pip install sklearn` it could potentially mean that people are unaware of the sklearn package deprecation, since they keep reusing the locally cached wheel.

At the same time most downloads are probably coming from CIs without pip caching so this may not be that important if the goal is to reduce `sklearn` downloads.

Downsides:
- the output is a bit more complicated in the case of succesful install, see below, but this is only a warning and most people will ignore it.

```
❯ pip install .
Processing /home/lesteve/dev/sklearn-pypi-package
  Preparing metadata (setup.py) ... done
Building wheels for collected packages: sklearn
  Building wheel for sklearn (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py bdist_wheel did not run successfully.
  │ exit code: 1
  ╰─> [2 lines of output]
      running bdist_wheel
      error: This is an expected error. Buidling wheel is disabled for the sklearn package to avoid client-side pip caching.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for sklearn
  Running setup.py clean for sklearn
Failed to build sklearn
Installing collected packages: sklearn
  Attempting uninstall: sklearn
    Found existing installation: sklearn 0.0.post1
    Uninstalling sklearn-0.0.post1:
      Successfully uninstalled sklearn-0.0.post1
  Running setup.py install for sklearn ... done
  DEPRECATION: sklearn was installed using the legacy 'setup.py install' method, because a wheel could not be built for it. A possible replacement is to fix the wheel build issue reported above. Discussion can be found at https://github.com/pypa/pip/issues/8368
Successfully installed sklearn-0.0.post1
```

- it would also require a new release e.g. 0.0.post2, which complicates the situation a bit more ...
- this seems a bit of a hack and I am not quite sure how robust this is
