### PR TITLE
setup.py: Remove trailing whitespace from error message

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ def likely_error():
     error_message = "\n".join(
         [
             "The 'sklearn' PyPI package is deprecated, use 'scikit-learn'",
-            "rather than 'sklearn' for pip commands. ",
+            "rather than 'sklearn' for pip commands.",
             "",
             "Here is how to fix this error in the main use cases:",
             "- use 'pip install scikit-learn' rather than 'pip install sklearn'",


### PR DESCRIPTION
This is an annoyance when writing tests asserting the exact shape of the error output.

My editor is set up to automatically remove trailing whitespace on save, making the existing test fixture invalid every time the file is saved.